### PR TITLE
feat(ui): VFD spindle warmup (fixes #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- VFD spindle warmup (fixes [#33](https://github.com/rsteckler/AxioCNC/issues/33)): optional warmup sequence for VFD spindles to redistribute grease before use. When enabled in Settings → Machine, the Spindle panel shows a Warmup button that steps through configurable min/max/step RPM with configurable dwell time at each speed. Warmup can be stopped via Stop Warmup or by the spindle stopping (e.g. e-stop); Start/Stop Spindle is hidden during warmup.
+
 - Added localization for:
 -- English
 -- Spanish

--- a/apps/shared/src/schemas/settings.js
+++ b/apps/shared/src/schemas/settings.js
@@ -30,6 +30,15 @@ const ToolSpinupSchema = z.object({
   delaySeconds: z.number().min(0).max(60).default(5),
 });
 
+// Spindle warmup (VFD): time at each speed, min/max/step RPM
+const SpindleWarmupSchema = z.object({
+  enabled: z.boolean().default(false),
+  timeSeconds: z.number().min(1).max(300).default(45),
+  minRpm: z.number().min(0).max(100000).default(8000),
+  maxRpm: z.number().min(0).max(100000).default(24000),
+  stepRpm: z.number().min(100).max(10000).default(2000),
+});
+
 export const MachineLimitsSchema = z.object({
   xmin: z.number().default(0),
   xmax: z.number().default(300),
@@ -44,6 +53,7 @@ export const MachineSettingsSchema = z.object({
   limits: MachineLimitsSchema.optional(),
   homingCorner: z.enum(['back-left', 'back-right', 'front-left', 'front-right']).optional(),
   toolSpinup: ToolSpinupSchema.optional(),
+  spindleWarmup: SpindleWarmupSchema.optional(),
   autoSwitchToMonitor: z.boolean().default(true),
 });
 
@@ -260,6 +270,7 @@ export const getDefaultSettings = () => {
     machine: MachineSettingsSchema.parse({
       limits: MachineLimitsSchema.parse({}),
       toolSpinup: ToolSpinupSchema.parse({}),
+      spindleWarmup: SpindleWarmupSchema.parse({}),
     }),
     connection: ConnectionSettingsSchema.parse({}),
     camera: CameraSettingsSchema.parse({}),

--- a/apps/web/src/routes/Settings/index.tsx
+++ b/apps/web/src/routes/Settings/index.tsx
@@ -117,6 +117,11 @@ const DEFAULT_MACHINE_CONFIG: MachineConfig = {
   autoSwitchToMonitorEnabled: true,   // Enabled by default
   toolSpinupDelayEnabled: true,   // Enabled by default
   toolSpinupDelaySeconds: 5,      // 5 seconds default delay
+  spindleWarmupEnabled: false,
+  spindleWarmupTimeSeconds: 45,
+  spindleWarmupMinRpm: 8000,
+  spindleWarmupMaxRpm: 24000,
+  spindleWarmupStepRpm: 2000,
 }
 
 // Default camera configuration
@@ -430,6 +435,21 @@ export default function Settings() {
       }
       if (settings.machine?.toolSpinup?.delaySeconds !== undefined) {
         setMachineConfig(prev => ({ ...prev, toolSpinupDelaySeconds: settings.machine!.toolSpinup!.delaySeconds! }))
+      }
+      if (settings.machine?.spindleWarmup?.enabled !== undefined) {
+        setMachineConfig(prev => ({ ...prev, spindleWarmupEnabled: settings.machine!.spindleWarmup!.enabled! }))
+      }
+      if (settings.machine?.spindleWarmup?.timeSeconds !== undefined) {
+        setMachineConfig(prev => ({ ...prev, spindleWarmupTimeSeconds: settings.machine!.spindleWarmup!.timeSeconds! }))
+      }
+      if (settings.machine?.spindleWarmup?.minRpm !== undefined) {
+        setMachineConfig(prev => ({ ...prev, spindleWarmupMinRpm: settings.machine!.spindleWarmup!.minRpm! }))
+      }
+      if (settings.machine?.spindleWarmup?.maxRpm !== undefined) {
+        setMachineConfig(prev => ({ ...prev, spindleWarmupMaxRpm: settings.machine!.spindleWarmup!.maxRpm! }))
+      }
+      if (settings.machine?.spindleWarmup?.stepRpm !== undefined) {
+        setMachineConfig(prev => ({ ...prev, spindleWarmupStepRpm: settings.machine!.spindleWarmup!.stepRpm! }))
       }
       
       // Connection config
@@ -922,6 +942,11 @@ export default function Settings() {
             autoSwitchToMonitorEnabled: importedSettings.machine?.autoSwitchToMonitor ?? prev.autoSwitchToMonitorEnabled,
             toolSpinupDelayEnabled: importedSettings.machine?.toolSpinup?.enabled ?? prev.toolSpinupDelayEnabled,
             toolSpinupDelaySeconds: importedSettings.machine?.toolSpinup?.delaySeconds ?? prev.toolSpinupDelaySeconds,
+            spindleWarmupEnabled: importedSettings.machine?.spindleWarmup?.enabled ?? prev.spindleWarmupEnabled,
+            spindleWarmupTimeSeconds: importedSettings.machine?.spindleWarmup?.timeSeconds ?? prev.spindleWarmupTimeSeconds,
+            spindleWarmupMinRpm: importedSettings.machine?.spindleWarmup?.minRpm ?? prev.spindleWarmupMinRpm,
+            spindleWarmupMaxRpm: importedSettings.machine?.spindleWarmup?.maxRpm ?? prev.spindleWarmupMaxRpm,
+            spindleWarmupStepRpm: importedSettings.machine?.spindleWarmup?.stepRpm ?? prev.spindleWarmupStepRpm,
           }))
         }
         
@@ -1096,6 +1121,13 @@ export default function Settings() {
         toolSpinup: {
           enabled: DEFAULT_MACHINE_CONFIG.toolSpinupDelayEnabled,
           delaySeconds: DEFAULT_MACHINE_CONFIG.toolSpinupDelaySeconds,
+        },
+        spindleWarmup: {
+          enabled: DEFAULT_MACHINE_CONFIG.spindleWarmupEnabled,
+          timeSeconds: DEFAULT_MACHINE_CONFIG.spindleWarmupTimeSeconds,
+          minRpm: DEFAULT_MACHINE_CONFIG.spindleWarmupMinRpm,
+          maxRpm: DEFAULT_MACHINE_CONFIG.spindleWarmupMaxRpm,
+          stepRpm: DEFAULT_MACHINE_CONFIG.spindleWarmupStepRpm,
         },
       },
       camera: DEFAULT_CAMERA_CONFIG,
@@ -1279,6 +1311,21 @@ export default function Settings() {
       if (changes.toolSpinupDelaySeconds !== undefined) {
         updated.toolSpinupDelaySeconds = changes.toolSpinupDelaySeconds
       }
+      if (changes.spindleWarmupEnabled !== undefined) {
+        updated.spindleWarmupEnabled = changes.spindleWarmupEnabled
+      }
+      if (changes.spindleWarmupTimeSeconds !== undefined) {
+        updated.spindleWarmupTimeSeconds = changes.spindleWarmupTimeSeconds
+      }
+      if (changes.spindleWarmupMinRpm !== undefined) {
+        updated.spindleWarmupMinRpm = changes.spindleWarmupMinRpm
+      }
+      if (changes.spindleWarmupMaxRpm !== undefined) {
+        updated.spindleWarmupMaxRpm = changes.spindleWarmupMaxRpm
+      }
+      if (changes.spindleWarmupStepRpm !== undefined) {
+        updated.spindleWarmupStepRpm = changes.spindleWarmupStepRpm
+      }
       return updated
     })
     
@@ -1301,6 +1348,31 @@ export default function Settings() {
       }
       if (changes.toolSpinupDelaySeconds !== undefined) {
         saveData.machine.toolSpinup.delaySeconds = changes.toolSpinupDelaySeconds
+      }
+    }
+    if (
+      changes.spindleWarmupEnabled !== undefined ||
+      changes.spindleWarmupTimeSeconds !== undefined ||
+      changes.spindleWarmupMinRpm !== undefined ||
+      changes.spindleWarmupMaxRpm !== undefined ||
+      changes.spindleWarmupStepRpm !== undefined
+    ) {
+      saveData.machine = saveData.machine || {}
+      saveData.machine.spindleWarmup = {}
+      if (changes.spindleWarmupEnabled !== undefined) {
+        saveData.machine.spindleWarmup.enabled = changes.spindleWarmupEnabled
+      }
+      if (changes.spindleWarmupTimeSeconds !== undefined) {
+        saveData.machine.spindleWarmup.timeSeconds = changes.spindleWarmupTimeSeconds
+      }
+      if (changes.spindleWarmupMinRpm !== undefined) {
+        saveData.machine.spindleWarmup.minRpm = changes.spindleWarmupMinRpm
+      }
+      if (changes.spindleWarmupMaxRpm !== undefined) {
+        saveData.machine.spindleWarmup.maxRpm = changes.spindleWarmupMaxRpm
+      }
+      if (changes.spindleWarmupStepRpm !== undefined) {
+        saveData.machine.spindleWarmup.stepRpm = changes.spindleWarmupStepRpm
       }
     }
     if (Object.keys(saveData).length > 0) {

--- a/apps/web/src/routes/Settings/sections/MachineSection.tsx
+++ b/apps/web/src/routes/Settings/sections/MachineSection.tsx
@@ -17,6 +17,55 @@ import { useMemo, useState, useEffect } from 'react'
 import { dimensionsToLimits, limitsToDimensions, type HomingCorner, type MachineDimensions } from '@/lib/machineLimits'
 import { useGetMachinePresetsQuery, type MachinePreset } from '@/services/api'
 
+/** Build warmup speeds from min to max by step, with max as final step */
+function getWarmupSpeeds(minRpm: number, maxRpm: number, stepRpm: number): number[] {
+  if (minRpm >= maxRpm || stepRpm <= 0) return [minRpm]
+  const speeds: number[] = []
+  for (let s = minRpm; s < maxRpm; s += stepRpm) {
+    speeds.push(s)
+  }
+  speeds.push(maxRpm)
+  return speeds
+}
+
+function WarmupPreview({
+  minRpm,
+  maxRpm,
+  stepRpm,
+  timeSeconds,
+}: {
+  minRpm: number
+  maxRpm: number
+  stepRpm: number
+  timeSeconds: number
+}) {
+  const { t } = useTranslation()
+  const speeds = useMemo(() => getWarmupSpeeds(minRpm, maxRpm, stepRpm), [minRpm, maxRpm, stepRpm])
+  const totalSeconds = speeds.length * timeSeconds
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  const durationText =
+    minutes > 0
+      ? t('Warmup will take {{minutes}} minutes, {{seconds}} seconds.', { minutes, seconds: Math.round(seconds) })
+      : t('Warmup will take {{seconds}} seconds.', { seconds: Math.round(seconds) })
+  const speedsText = speeds.join(' > ')
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 space-y-1 text-sm">
+      <p className="text-muted-foreground font-medium">{t('Speeds (RPM)')}</p>
+      <p className="font-mono text-xs break-all">{speedsText}</p>
+      <p className="text-muted-foreground">{durationText}</p>
+    </div>
+  )
+}
+
+export interface SpindleWarmupConfig {
+  enabled: boolean
+  timeSeconds: number
+  minRpm: number
+  maxRpm: number
+  stepRpm: number
+}
+
 export interface MachineConfig {
   name: string
   limits: {
@@ -31,6 +80,11 @@ export interface MachineConfig {
   autoSwitchToMonitorEnabled: boolean
   toolSpinupDelayEnabled: boolean
   toolSpinupDelaySeconds: number
+  spindleWarmupEnabled: boolean
+  spindleWarmupTimeSeconds: number
+  spindleWarmupMinRpm: number
+  spindleWarmupMaxRpm: number
+  spindleWarmupStepRpm: number
 }
 
 interface MachineSectionProps {
@@ -415,6 +469,106 @@ export function MachineSection({
               <span className="text-sm text-muted-foreground whitespace-nowrap">{t('seconds')}</span>
             </div>
           </SettingsField>
+        )}
+
+        <SettingsField
+          label={t('Spindle Warmup (VFD)')}
+          description={t('Run a warmup sequence before use to redistribute grease in VFD spindles')}
+          tooltip={t('When enabled, a Warmup button appears on the Spindle panel. Warmup steps through speeds from minimum to maximum, dwelling at each for the configured time.')}
+          horizontal
+        >
+          <Switch
+            checked={config.spindleWarmupEnabled}
+            onCheckedChange={(checked) => onConfigChange({ spindleWarmupEnabled: checked })}
+          />
+        </SettingsField>
+
+        {config.spindleWarmupEnabled && (
+          <>
+            <SettingsField
+              label={t('Time at each speed')}
+              description={t('Seconds to run at each speed step')}
+            >
+              <div className="flex items-center gap-2 max-w-xs">
+                <Input
+                  type="number"
+                  step="1"
+                  min="1"
+                  max="300"
+                  value={config.spindleWarmupTimeSeconds}
+                  onChange={(e) => {
+                    const value = Math.max(1, Math.min(300, parseInt(e.target.value, 10) || 45))
+                    onConfigChange({ spindleWarmupTimeSeconds: value })
+                  }}
+                  className="h-9"
+                />
+                <span className="text-sm text-muted-foreground whitespace-nowrap">{t('seconds')}</span>
+              </div>
+            </SettingsField>
+            <SettingsField
+              label={t('Minimum speed')}
+              description={t('Starting RPM for warmup')}
+            >
+              <div className="flex items-center gap-2 max-w-xs">
+                <Input
+                  type="number"
+                  step="100"
+                  min="0"
+                  value={config.spindleWarmupMinRpm}
+                  onChange={(e) => {
+                    const value = Math.max(0, parseInt(e.target.value, 10) || 8000)
+                    onConfigChange({ spindleWarmupMinRpm: value })
+                  }}
+                  className="h-9"
+                />
+                <span className="text-sm text-muted-foreground whitespace-nowrap">{t('RPM')}</span>
+              </div>
+            </SettingsField>
+            <SettingsField
+              label={t('Maximum speed')}
+              description={t('Ending RPM for warmup')}
+            >
+              <div className="flex items-center gap-2 max-w-xs">
+                <Input
+                  type="number"
+                  step="100"
+                  min="0"
+                  value={config.spindleWarmupMaxRpm}
+                  onChange={(e) => {
+                    const value = Math.max(0, parseInt(e.target.value, 10) || 24000)
+                    onConfigChange({ spindleWarmupMaxRpm: value })
+                  }}
+                  className="h-9"
+                />
+                <span className="text-sm text-muted-foreground whitespace-nowrap">{t('RPM')}</span>
+              </div>
+            </SettingsField>
+            <SettingsField
+              label={t('Step change')}
+              description={t('RPM increase between each speed step')}
+            >
+              <div className="flex items-center gap-2 max-w-xs">
+                <Input
+                  type="number"
+                  step="100"
+                  min="100"
+                  value={config.spindleWarmupStepRpm}
+                  onChange={(e) => {
+                    const value = Math.max(100, parseInt(e.target.value, 10) || 2000)
+                    onConfigChange({ spindleWarmupStepRpm: value })
+                  }}
+                  className="h-9"
+                />
+                <span className="text-sm text-muted-foreground whitespace-nowrap">{t('RPM')}</span>
+              </div>
+            </SettingsField>
+            <WarmupPreview
+              minRpm={config.spindleWarmupMinRpm}
+              maxRpm={config.spindleWarmupMaxRpm}
+              stepRpm={config.spindleWarmupStepRpm}
+              timeSeconds={config.spindleWarmupTimeSeconds}
+            />
+          </>
         )}
       </div>
     </SettingsSection>

--- a/apps/web/src/routes/Setup/panels/SpindlePanel.tsx
+++ b/apps/web/src/routes/Setup/panels/SpindlePanel.tsx
@@ -1,13 +1,30 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RotateCw, RotateCcw, Circle } from 'lucide-react'
+import { RotateCw, RotateCcw, Circle, ThermometerSun, Square } from 'lucide-react'
 import { Slider } from '@/components/ui/slider'
 import { MachineActionButton } from '@/components/MachineActionButton'
 import { MachineActionWrapper } from '@/components/MachineActionWrapper'
 import { ActionRequirements } from '@/utils/machineState'
 import { useGcodeCommand } from '@/hooks'
 import { trackFeatureUsed } from '@/services/analytics'
+import { useGetSettingsQuery } from '@/services/api'
 import type { PanelProps } from '../types'
+
+function getWarmupSpeeds(minRpm: number, maxRpm: number, stepRpm: number): number[] {
+  if (minRpm >= maxRpm || stepRpm <= 0) return [minRpm]
+  const speeds: number[] = []
+  for (let s = minRpm; s < maxRpm; s += stepRpm) {
+    speeds.push(s)
+  }
+  speeds.push(maxRpm)
+  return speeds
+}
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return m > 0 ? `${m}:${s.toString().padStart(2, '0')}` : `0:${s.toString().padStart(2, '0')}`
+}
 
 export function SpindlePanel({ 
   isConnected, 
@@ -19,6 +36,7 @@ export function SpindlePanel({
   spindleSpeed = 0 
 }: PanelProps) {
   const { t } = useTranslation()
+  const { data: settings } = useGetSettingsQuery()
   // Generate speeds array from 8000 to 24000 in 100 RPM increments
   const speeds = Array.from({ length: 161 }, (_, i) => 8000 + i * 100)
   
@@ -27,6 +45,94 @@ export function SpindlePanel({
   
   // G-code command hook
   const { sendGcode } = useGcodeCommand(connectedPort)
+
+  // Spindle warmup (VFD) from machine settings
+  const warmupConfig = settings?.machine?.spindleWarmup
+  const warmupEnabled = warmupConfig?.enabled ?? false
+  const warmupTimeSeconds = Math.max(1, Math.min(300, warmupConfig?.timeSeconds ?? 45))
+  const warmupMinRpm = warmupConfig?.minRpm ?? 8000
+  const warmupMaxRpm = warmupConfig?.maxRpm ?? 24000
+  const warmupStepRpm = Math.max(100, warmupConfig?.stepRpm ?? 2000)
+
+  const [isWarmupRunning, setIsWarmupRunning] = useState(false)
+  const [warmupRemainingSeconds, setWarmupRemainingSeconds] = useState(0)
+  const warmupTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const warmupIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const warmupCancelledRef = useRef(false)
+  const prevSpindleStateRef = useRef<string>(spindleState)
+
+  const clearWarmupTimers = useCallback(() => {
+    warmupTimeoutsRef.current.forEach(clearTimeout)
+    warmupTimeoutsRef.current = []
+    if (warmupIntervalRef.current) {
+      clearInterval(warmupIntervalRef.current)
+      warmupIntervalRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      clearWarmupTimers()
+    }
+  }, [clearWarmupTimers])
+
+  // If spindle stops while warmup is running (e.g. e-stop), end warmup.
+  // Only react to transition from M3/M4 → M5, not M5 at start (machine needs time to report M3).
+  useEffect(() => {
+    const wasOn = prevSpindleStateRef.current === 'M3' || prevSpindleStateRef.current === 'M4'
+    prevSpindleStateRef.current = spindleState
+    if (isWarmupRunning && wasOn && spindleState === 'M5') {
+      warmupCancelledRef.current = true
+      clearWarmupTimers()
+      setIsWarmupRunning(false)
+      setWarmupRemainingSeconds(0)
+    }
+  }, [isWarmupRunning, spindleState, clearWarmupTimers])
+
+  const handleStopWarmup = useCallback(() => {
+    warmupCancelledRef.current = true
+    clearWarmupTimers()
+    sendGcode('M5')
+    setIsWarmupRunning(false)
+    setWarmupRemainingSeconds(0)
+    trackFeatureUsed('spindle', 'SpindlePanel', 'warmup_stop', '')
+  }, [clearWarmupTimers, sendGcode])
+
+  const handleStartWarmup = useCallback(() => {
+    if (!connectedPort || isWarmupRunning) return
+    warmupCancelledRef.current = false
+    const warmupSpeeds = getWarmupSpeeds(warmupMinRpm, warmupMaxRpm, warmupStepRpm)
+    const totalSeconds = warmupSpeeds.length * warmupTimeSeconds
+    setIsWarmupRunning(true)
+    setWarmupRemainingSeconds(totalSeconds)
+
+    const intervalId = setInterval(() => {
+      setWarmupRemainingSeconds(prev => Math.max(0, prev - 1))
+    }, 1000)
+    warmupIntervalRef.current = intervalId
+
+    warmupSpeeds.forEach((rpm, i) => {
+      const timeoutId = setTimeout(() => {
+        if (warmupCancelledRef.current) return
+        sendGcode(`M3 S${rpm}`)
+      }, i * warmupTimeSeconds * 1000)
+      warmupTimeoutsRef.current.push(timeoutId)
+    })
+    const stopTimeoutId = setTimeout(() => {
+      if (warmupCancelledRef.current) return
+      sendGcode('M5')
+      clearWarmupTimers()
+      if (warmupIntervalRef.current) {
+        clearInterval(warmupIntervalRef.current)
+        warmupIntervalRef.current = null
+      }
+      setIsWarmupRunning(false)
+      setWarmupRemainingSeconds(0)
+      trackFeatureUsed('spindle', 'SpindlePanel', 'warmup_complete', '')
+    }, warmupSpeeds.length * warmupTimeSeconds * 1000)
+    warmupTimeoutsRef.current.push(stopTimeoutId)
+    trackFeatureUsed('spindle', 'SpindlePanel', 'warmup_start', `${warmupSpeeds.length}_${warmupTimeSeconds}s`)
+  }, [connectedPort, isWarmupRunning, warmupMinRpm, warmupMaxRpm, warmupStepRpm, warmupTimeSeconds, sendGcode, clearWarmupTimers])
   
   // Derive state from backend
   const isOn = spindleState === 'M3' || spindleState === 'M4'
@@ -65,12 +171,12 @@ export function SpindlePanel({
   
   const [speedIndex, setSpeedIndex] = useState(() => getSpeedIndex(spindleSpeed))
   
-  // Update speed index when backend speed changes (only if spindle is off)
+  // Sync slider to backend speed whenever it changes (e.g. during warmup or after start/stop)
   useEffect(() => {
-    if (!isOn && spindleSpeed !== undefined) {
+    if (spindleSpeed !== undefined) {
       setSpeedIndex(getSpeedIndex(spindleSpeed))
     }
-  }, [spindleSpeed, isOn, getSpeedIndex])
+  }, [spindleSpeed, getSpeedIndex])
   
   const speed = speeds[speedIndex]
   
@@ -220,28 +326,78 @@ export function SpindlePanel({
         </div>
       </div>
       
-      {/* On/Off toggle */}
+      {/* Spindle warmup (VFD) - when enabled in Machine settings */}
+      {warmupEnabled && (
+        <div className="space-y-1">
+          {isWarmupRunning ? (
+            <>
+              <MachineActionButton
+                isConnected={isConnected}
+                connectedPort={connectedPort}
+                machineStatus={machineStatus}
+                onFlashStatus={onFlashStatus}
+                onAction={handleStopWarmup}
+                requirements={ActionRequirements.allowHold}
+                className="w-full h-12 bg-red-600 hover:bg-red-700"
+                variant="default"
+              >
+                <Square className="w-4 h-4 mr-2 fill-white" />
+                {t('Stop Warmup')}
+              </MachineActionButton>
+              <p className="text-center text-sm font-mono text-muted-foreground">
+                {t('Time remaining')}: {formatCountdown(warmupRemainingSeconds)}
+              </p>
+            </>
+          ) : (
+            <MachineActionButton
+              isConnected={isConnected}
+              connectedPort={connectedPort}
+              machineStatus={machineStatus}
+              onFlashStatus={onFlashStatus}
+              onAction={handleStartWarmup}
+              requirements={{
+                requiresConnected: true,
+                requiresPort: true,
+                disallowAlarm: true,
+                disallowRunning: true,
+                disallowHold: true,
+                disallowNotConnected: true,
+              }}
+              customDisabled={isJobRunning}
+              className="w-full h-12"
+              variant="outline"
+            >
+              <ThermometerSun className="w-4 h-4 mr-2" />
+              {t('Warmup Spindle')}
+            </MachineActionButton>
+          )}
+        </div>
+      )}
+
+      {/* On/Off toggle - hidden while warmup is running */}
+      {!isWarmupRunning && (
         <MachineActionButton
-        isConnected={isConnected}
-        connectedPort={connectedPort}
-        machineStatus={machineStatus}
-        onFlashStatus={onFlashStatus}
-        onAction={handleToggleSpindle}
-        requirements={isOn ? ActionRequirements.allowHold : {
-          requiresConnected: true,
-          requiresPort: true,
-          disallowAlarm: true,
-          disallowRunning: false, // Allow spindle start during jobs (but not during hold)
-          disallowHold: true, // Don't allow starting spindle during hold
-          disallowNotConnected: true,
-        }}
-        customDisabled={!isOn && (isJobRunning && machineStatus !== 'hold')} // Allow stop during hold, disable start during other running states
-        className={`w-full h-12 ${isOn ? 'bg-green-600 hover:bg-green-700' : ''}`}
-        variant={isOn ? 'default' : 'outline'}
-      >
-        <Circle className={`w-4 h-4 mr-2 ${isOn ? 'fill-white' : ''}`} />
-        {isOn ? t('Stop Spindle') : t('Start Spindle')}
-      </MachineActionButton>
+          isConnected={isConnected}
+          connectedPort={connectedPort}
+          machineStatus={machineStatus}
+          onFlashStatus={onFlashStatus}
+          onAction={handleToggleSpindle}
+          requirements={isOn ? ActionRequirements.allowHold : {
+            requiresConnected: true,
+            requiresPort: true,
+            disallowAlarm: true,
+            disallowRunning: false, // Allow spindle start during jobs (but not during hold)
+            disallowHold: true, // Don't allow starting spindle during hold
+            disallowNotConnected: true,
+          }}
+          customDisabled={!isOn && (isJobRunning && machineStatus !== 'hold')} // Allow stop during hold, disable start during other running states
+          className={`w-full h-12 ${isOn ? 'bg-green-600 hover:bg-green-700' : ''}`}
+          variant={isOn ? 'default' : 'outline'}
+        >
+          <Circle className={`w-4 h-4 mr-2 ${isOn ? 'fill-white' : ''}`} />
+          {isOn ? t('Stop Spindle') : t('Start Spindle')}
+        </MachineActionButton>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
- Add spindle warmup settings in Machine section: enable, time per step, min/max/step RPM with preview of speeds and total duration
- Add Warmup Spindle button on Setup Spindle panel when enabled; shows Stop Warmup and countdown while running
- Sync speed slider to backend during warmup; hide Start/Stop Spindle during warmup; end warmup when spindle stops (e.g. e-stop)
- Persist warmup config in settings (shared schema + Settings load/save)

Thanks to [Jarret Palodichuk](https://community.carbide3d.com/u/Pchuk) for the idea, here: https://community.carbide3d.com/t/built-a-new-controller-app-feedback-wanted/100618/19?u=cryptyk